### PR TITLE
improve anti-windup

### DIFF
--- a/src/common/pid.cpp
+++ b/src/common/pid.cpp
@@ -29,8 +29,8 @@ float PIDController::operator() (float error){
     // Tustin transform of the integral part
     // u_ik = u_ik_1  + I*Ts/2*(ek + ek_1)
     float integral = integral_prev + I*Ts*0.5*(error + error_prev);
-    // antiwindup - limit the output
-    integral = _constrain(integral, -limit, limit);
+    // antiwindup - limit the accumulator
+    integral = _constrain(integral, -(limit-proportional), limit-proportional);
     // Discrete derivation
     // u_dk = D(ek - ek_1)/Ts
     float derivative = D*(error - error_prev)/Ts;


### PR DESCRIPTION
small change, huge effect
The controller stability can be improved by limiting the charge level of the accumulator to the value needed to reach "output=limit".
While the output is limited, the controller is not able to react. But when the system will be release, the integrator will start to discharge at a lower value.
Considering the proportional part for limitation will enable the controller to return quicker into contentious mode.
There are several ways to realize anti-windup schemes, but this small improvement is quite easy to implement.